### PR TITLE
feat: add timeout and backoff retries

### DIFF
--- a/packages/node/src/client.ts
+++ b/packages/node/src/client.ts
@@ -7,6 +7,7 @@ import { SkylabUser } from './types/user';
 import { Variant, Variants } from './types/variant';
 import { urlSafeBase64Encode } from './util/encode';
 import { performance } from './util/performance';
+import { sleep } from './util/time';
 
 /**
  * Main client for fetching variant data.
@@ -35,48 +36,103 @@ export class SkylabClient {
     this.debug = this.config?.debug;
   }
 
-  private async fetchAll(
-    user: SkylabUser,
-  ): Promise<{ [flagKey: string]: Variant }> {
-    try {
-      const start = performance.now();
-      const userContext = this.addContext(user || {});
-      const encodedContext = urlSafeBase64Encode(JSON.stringify(userContext));
-      const endpoint = `${this.config.serverUrl}/sdk/vardata/${encodedContext}`;
-      const headers = {
-        Authorization: `Api-Key ${this.apiKey}`,
-      };
-      const response = await this.httpClient.request(endpoint, 'GET', headers);
-      if (response.status === 200) {
-        const json = JSON.parse(response.body);
-        const end = performance.now();
-        const variants: Variants = {};
-        for (const key of Object.keys(json)) {
-          let value;
-          if ('value' in json[key]) {
-            value = json[key].value;
-          } else if ('key' in json[key]) {
-            // value was previously under the "key" field
-            value = json[key].key;
-          }
-          const variant: Variant = {
-            value,
-            payload: json[key].payload,
-          };
-          variants[key] = variant;
-        }
-        this.debug &&
-          console.debug(
-            `[Skylab] Fetched all variants in ${(end - start).toFixed(3)} ms`,
-          );
-        return variants;
-      } else {
-        console.error(`[Skylab] Received ${response.status}: ${response.body}`);
-      }
-    } catch (e) {
-      console.error(e);
+  protected async fetchAll(user: SkylabUser): Promise<Variants> {
+    if (!this.apiKey) {
+      throw Error('Skylab API key is empty');
     }
-    return {};
+    if (this.debug) {
+      console.debug('[Skylab] Fetching variants for user: ', user);
+    }
+    try {
+      return await this.doFetch(user, this.config.fetchTimeoutMillis);
+    } catch (e) {
+      console.error('[Skylab] Fetch failed: ', e);
+      try {
+        return await this.retryFetch(user);
+      } catch (e) {
+        console.error(e);
+      }
+      throw e;
+    }
+  }
+
+  protected async doFetch(
+    user: SkylabUser,
+    timeoutMillis: number,
+  ): Promise<Variants> {
+    const start = performance.now();
+    const userContext = this.addContext(user || {});
+    const encodedContext = urlSafeBase64Encode(JSON.stringify(userContext));
+    const endpoint = `${this.config.serverUrl}/sdk/vardata/${encodedContext}`;
+    const headers = {
+      Authorization: `Api-Key ${this.apiKey}`,
+    };
+    const response = await this.httpClient.request(
+      endpoint,
+      'GET',
+      headers,
+      null,
+      timeoutMillis,
+    );
+    if (response.status !== 200) {
+      throw Error(
+        `Received error response: ${response.status}: ${response.body}`,
+      );
+    }
+    const elapsed = (performance.now() - start).toFixed(3);
+    if (this.debug) {
+      console.debug(`[Skylab] Fetch complete in ${elapsed} ms`);
+    }
+    const json = JSON.parse(response.body);
+    const variants = this.parseJsonVariants(json);
+    if (this.debug) {
+      console.debug(`[Skylab] Fetched variants: ${variants}`);
+    }
+    return variants;
+  }
+
+  protected async retryFetch(user: SkylabUser): Promise<Variants> {
+    if (this.config.fetchRetries == 0) {
+      return {};
+    }
+    if (this.debug) {
+      console.debug('[Skylab] Retrying fetch');
+    }
+    let err: Error = null;
+    let delayMillis = this.config.fetchRetryBackoffMinMillis;
+    for (let i = 0; i < this.config.fetchRetries; i++) {
+      await sleep(delayMillis);
+      try {
+        return await this.doFetch(user, this.config.fetchRetryTimeoutMillis);
+      } catch (e) {
+        console.error('[Skylab] Retry falied: ', e);
+        err = e;
+      }
+      delayMillis = Math.min(
+        delayMillis * this.config.fetchRetryBackoffScalar,
+        this.config.fetchRetryBackoffMaxMillis,
+      );
+    }
+    throw err;
+  }
+
+  protected async parseJsonVariants(json: string): Promise<Variants> {
+    const variants: Variants = {};
+    for (const key of Object.keys(json)) {
+      let value;
+      if ('value' in json[key]) {
+        value = json[key].value;
+      } else if ('key' in json[key]) {
+        // value was previously under the "key" field
+        value = json[key].key;
+      }
+      const variant: Variant = {
+        value,
+        payload: json[key].payload,
+      };
+      variants[key] = variant;
+    }
+    return variants;
   }
 
   private addContext(user: SkylabUser): SkylabUser {
@@ -92,9 +148,13 @@ export class SkylabClient {
    */
   public async getVariants(user: SkylabUser): Promise<Variants> {
     if (!this.apiKey) {
+      throw Error('Skylab API key is empty');
+    }
+    try {
+      return await this.fetchAll(user);
+    } catch (e) {
+      console.error('[Skylab] Failed to fetch variants: ', e);
       return {};
     }
-    const variants = await this.fetchAll(user);
-    return variants;
   }
 }

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -59,10 +59,10 @@ export type SkylabConfig = {
  | **instanceName** | `"$default_instance"`             |
  | **serverUrl**    | `"https://api.lab.amplitude.com"` |
  | **fetchTimeoutMillis**    | `10000` |
- | **fetchRetries**    | `5` |
+ | **fetchRetries**    | `8` |
  | **fetchRetryBackoffMinMillis**    | `500` |
  | **fetchRetryBackoffMaxMillis**    | `10000` |
- | **fetchRetryBackoffScalar**    | `2` |
+ | **fetchRetryBackoffScalar**    | `1.5` |
  | **fetchRetryTimeoutMillis**    | `10000` |
 
 

--- a/packages/node/src/config.ts
+++ b/packages/node/src/config.ts
@@ -16,6 +16,38 @@ export type SkylabConfig = {
    * The server endpoint from which to request variants.
    */
   serverUrl?: string;
+
+  /**
+   * The request timeout, in milliseconds, used when fetching variants triggered by calling start() or setUser().
+   */
+  fetchTimeoutMillis?: number;
+
+  /**
+   * The number of retries to attempt before failing
+   */
+  fetchRetries?: number;
+
+  /**
+   * Retry backoff minimum (starting backoff delay) in milliseconds. The minimum backoff is scaled by
+   * `fetchRetryBackoffScalar` after each retry failure.
+   */
+  fetchRetryBackoffMinMillis: number;
+
+  /**
+   * Retry backoff maximum in milliseconds. If the scaled backoff is greater than the max, the max is
+   * used for all subsequent retries.
+   */
+  fetchRetryBackoffMaxMillis: number;
+
+  /**
+   * Scales the minimum backoff exponentially.
+   */
+  fetchRetryBackoffScalar: number;
+
+  /**
+   * The request timeout for retrying fetch requests.
+   */
+  fetchRetryTimeoutMillis?: number;
 };
 
 /**
@@ -26,6 +58,13 @@ export type SkylabConfig = {
  | **debug**        | false                           |
  | **instanceName** | `"$default_instance"`             |
  | **serverUrl**    | `"https://api.lab.amplitude.com"` |
+ | **fetchTimeoutMillis**    | `10000` |
+ | **fetchRetries**    | `5` |
+ | **fetchRetryBackoffMinMillis**    | `500` |
+ | **fetchRetryBackoffMaxMillis**    | `10000` |
+ | **fetchRetryBackoffScalar**    | `2` |
+ | **fetchRetryTimeoutMillis**    | `10000` |
+
 
  *
  * @category Configuration
@@ -34,4 +73,10 @@ export const Defaults: SkylabConfig = {
   debug: false,
   instanceName: '$default_instance',
   serverUrl: 'https://api.lab.amplitude.com',
+  fetchTimeoutMillis: 10000,
+  fetchRetries: 8,
+  fetchRetryBackoffMinMillis: 500,
+  fetchRetryBackoffMaxMillis: 10000,
+  fetchRetryBackoffScalar: 1.5,
+  fetchRetryTimeoutMillis: 10000,
 };

--- a/packages/node/src/transport/http.ts
+++ b/packages/node/src/transport/http.ts
@@ -17,6 +17,7 @@ const request: HttpClient['request'] = (
   method: string,
   headers: Record<string, string>,
   data?: Record<string, string>,
+  timeoutMillis?: number,
 ): Promise<SimpleResponse> => {
   const urlParams = url.parse(requestUrl);
   if (method === 'GET' && data) {
@@ -28,11 +29,20 @@ const request: HttpClient['request'] = (
     ...urlParams,
     method,
     headers,
+    // Adds timeout to the socket connection, not the response.
+    timeout: timeoutMillis,
   };
 
   return new Promise((resolve, reject) => {
     const protocol = urlParams.protocol === 'http:' ? http : https;
-    const req = protocol.request(options, (res) => {
+    const req = protocol.request(options);
+
+    const responseTimeout = setTimeout(() => {
+      req.destroy(Error('Response timed out'));
+    }, timeoutMillis);
+
+    req.on('response', (res) => {
+      clearTimeout(responseTimeout);
       res.setEncoding('utf-8');
       let responseBody = '';
 
@@ -48,10 +58,15 @@ const request: HttpClient['request'] = (
       });
     });
 
+    req.on('timeout', () => req.destroy(Error('Socket connection timed out')));
+
     req.on('error', reject);
+
     if (method !== 'GET' && data) {
       req.write(data);
     }
+
+    req.on('close', () => clearTimeout(responseTimeout));
     req.end();
   });
 };

--- a/packages/node/src/types/transport.ts
+++ b/packages/node/src/types/transport.ts
@@ -9,5 +9,6 @@ export interface HttpClient {
     method: string,
     headers: Record<string, string>,
     data?: Record<string, string>,
+    timeoutMillis?: number,
   ): Promise<SimpleResponse>;
 }

--- a/packages/node/src/util/time.ts
+++ b/packages/node/src/util/time.ts
@@ -1,0 +1,6 @@
+export const sleep = (millis: number): Promise<void> => {
+  if (millis === 0) {
+    return;
+  }
+  return new Promise((resolve) => setTimeout(resolve, millis));
+};


### PR DESCRIPTION
<!---
Thanks for contributing to the Amplitude JavaScript Server SDK! 🎉

Please fill out the following sections to help us quickly review your pull request.
--->

### Summary

<!-- What does the PR do? -->

This implementation differs from the client side in that the retires are limited and can be configured with an exponential backoff. The `fetchAll` function differs from the client js sdk code in that it does not start a periodic timeout. Rather, it calls `retryFetch` which calls `doFetch` abiding by the number of retries and backoff policy configured by the caller.

This change in behavior compared to the client is because the server does not fallback or storage, and thus a background interval serves no purpose.

### Checklist

* [x] Does your PR title have the correct [title format](https://github.com/amplitude/skylabs-js-server/blob/main/CONTRIBUTING.md#pr-commit-title-conventions)?
* Does your PR have a breaking change?:  <!-- Yes or no --> No
